### PR TITLE
Fixing compilation on Linux Mint 17.1 (Ubuntu 14.04)

### DIFF
--- a/scripts/makeDistortosConfiguration.awk
+++ b/scripts/makeDistortosConfiguration.awk
@@ -1,4 +1,4 @@
-#!/bin/awk -f
+#!/usr/bin/awk -f
 
 #
 # file: makeDistortosConfiguration.awk

--- a/source/chip/STMicroelectronics/STM32F4/STM32F4.ld.sh
+++ b/source/chip/STMicroelectronics/STM32F4/STM32F4.ld.sh
@@ -25,7 +25,7 @@ if [ ! -f $1 ]; then
 fi
 
 # source the configuration file provided as argument to read all the configuration variables
-source $1
+. $1
 
 if [ $CONFIG_CHIP_STM32F4_FLASH_SIZE -eq 0 ] || [ $CONFIG_CHIP_STM32F4_SRAM1_SIZE -eq 0 ]; then
 	echo "CONFIG_CHIP_STM32F4_FLASH_SIZE and CONFIG_CHIP_STM32F4_SRAM1_SIZE cannot be 0!" >&2


### PR DESCRIPTION
On Linux Mint 17.1 (Ubuntu 14.04 based), awk is located in "/usr/bin/".
Ubuntu uses dash for /bin/sh and dash doesn't support the "source"
keyword. This is a bash extension. The POSIX command for sourcing
other scripts is '.' .

Signed-off-by: Jasmin Jessich <jasmin@anw.at>