### PR TITLE
Introduce verbose mode to traditional make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,14 @@ CHIP_INCLUDES += $(patsubst %,-I%,$(subst ",,$(CONFIG_CHIP_INCLUDES)))
 #-----------------------------------------------------------------------------------------------------------------------
 # build macros
 #-----------------------------------------------------------------------------------------------------------------------
+#verbose mode
+VERBOSE ?= 0
+
+ifeq ($(VERBOSE), 0)
+Q = @
+else
+Q =
+endif
 
 define DIRECTORY_DEPENDENCY
 $(1): | $(dir $(1))
@@ -126,7 +134,7 @@ endef
 
 define MAKE_DIRECTORY
 $(1):
-	mkdir -p $(1)
+	$(Q)mkdir -p $(1)
 endef
 
 define PARSE_SUBDIRECTORY
@@ -174,37 +182,46 @@ $(OBJECTS): $(OUTPUT)include/distortos/distortosConfiguration.h
 $(GENERATED): Makefile
 
 $(OUTPUT)%.o: %.S
-	$(AS) $(ASFLAGS) $(ASFLAGS_$(<)) -c $< -o $@
+	@echo " AS     " $< 
+	$(Q)$(AS) $(ASFLAGS) $(ASFLAGS_$(<)) -c $< -o $@
 
 $(OUTPUT)%.o: %.c
-	$(CC) $(CFLAGS) $(CFLAGS_$(<)) -c $< -o $@
+	@echo " CC     " $<
+	$(Q)$(CC) $(CFLAGS) $(CFLAGS_$(<)) -c $< -o $@
 
 $(OUTPUT)%.o: %.cpp
-	$(CXX) $(CXXFLAGS) $(CXXFLAGS_$(<)) -c $< -o $@
+	@echo " CXX    " $<
+	$(Q)$(CXX) $(CXXFLAGS) $(CXXFLAGS_$(<)) -c $< -o $@
 
 $(OUTPUT)%.a:
-	rm -f $@
-	$(AR) rcs $@ $(filter %.o,$(^))
+	$(Q)rm -f $@
+	@echo " AR     " $@
+	$(Q)$(AR) rcs $@ $(filter %.o,$(^))
 
 $(OUTPUT)%.elf:
+	@echo " LD     " $@
 	$(eval ARCHIVES_$@ := -Wl,--whole-archive $(addprefix -l:,$(filter %.a,$(^))) -Wl,--no-whole-archive)
-	$(LD) $(LDFLAGS) -T$(filter %.ld,$(^)) $(filter %.o,$(^)) $(ARCHIVES_$(@)) -o $@
+	$(Q)$(LD) $(LDFLAGS) -T$(filter %.ld,$(^)) $(filter %.o,$(^)) $(ARCHIVES_$(@)) -o $@
 
 $(OUTPUT)%.hex:
-	$(OBJCOPY) -O ihex $(filter %.elf,$(^)) $@
+	@echo " HEX    " $@
+	$(Q)$(OBJCOPY) -O ihex $(filter %.elf,$(^)) $@
 
 $(OUTPUT)%.bin:
-	$(OBJCOPY) -O binary $(filter %.elf,$(^)) $@
+	@echo " BIN    " $@
+	$(Q)$(OBJCOPY) -O binary $(filter %.elf,$(^)) $@
 
 $(OUTPUT)%.dmp:
-	$(OBJDUMP) -x --syms --demangle $(filter %.elf,$(^)) > $@
+	@echo " DMP    " $@
+	$(Q)$(OBJDUMP) -x --syms --demangle $(filter %.elf,$(^)) > $@
 
 $(OUTPUT)%.lss:
-	$(OBJDUMP) --demangle -S $(filter %.elf,$(^)) > $@
+	@echo " LSS    " $@
+	$(Q)$(OBJDUMP) --demangle -S $(filter %.elf,$(^)) > $@
 
 .PHONY: size
 size:
-	$(SIZE) -B $(filter %.elf,$(^))
+	$(Q)$(SIZE) -B $(filter %.elf,$(^))
 
 .PHONY: clean
 clean:

--- a/Rules.mk
+++ b/Rules.mk
@@ -23,7 +23,8 @@ SUBDIRECTORIES += test
 DISTORTOS_CONFIGURATION_H := $(OUTPUT)include/distortos/distortosConfiguration.h
 
 $(DISTORTOS_CONFIGURATION_H): $(DISTORTOS_CONFIGURATION_MK)
-	./scripts/makeDistortosConfiguration.awk "$(dir $<)$(notdir $<)" > "$@"
+	@echo " AWK    " scripts/makeDistortosConfiguration.awk
+	$(Q)./scripts/makeDistortosConfiguration.awk "$(dir $<)$(notdir $<)" > "$@"
 
 #-----------------------------------------------------------------------------------------------------------------------
 # generated headers depend on this Rules.mk, the script that generates them and the selectedConfiguration.mk file

--- a/source/chip/STMicroelectronics/STM32F4/Rules.mk
+++ b/source/chip/STMicroelectronics/STM32F4/Rules.mk
@@ -16,7 +16,8 @@
 STM32F4_LD_SH := $(d)/STM32F4.ld.sh
 
 $(LDSCRIPT): $(DISTORTOS_CONFIGURATION_MK)
-	./$(STM32F4_LD_SH) "$(dir $<)$(notdir $<)" > "$@"
+	@echo " SH     " $(STM32F4_LD_SH)
+	$(Q)./$(STM32F4_LD_SH) "$(dir $<)$(notdir $<)" > "$@"
 
 #-----------------------------------------------------------------------------------------------------------------------
 # generated linker script depends on this Rules.mk, the script that generates it and the selectedConfiguration.mk file


### PR DESCRIPTION
It is nice when compilation log is short and clear. End user could
also decide how to call make:
 - make VERBOSE=1 to see full compilation log
 - make to see short log