### PR TITLE
Modify generateBoard.py to work in both Python 2 and 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file. This projec
 
 - Board generator script written in *Python* with *Jinja2* template engine, which uses configuration files in `.json`
 format. This new feature can be used with `make board CONFIG_FILE=path/to/config.json` command. `.json` configuration
-files were added for all supported boards and all of their source files were regenerated with the script.
+files were added for all supported boards and all of their source files were regenerated with the script. The script is
+usable with both *Python 2* and *Python 3*.
 - Test of `Thread::generateSignal()` and `Thread::queueSignal()` returning `ENOSPC` when the amount of target thread's
 free stack is too small to request signal delivery.
 

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ CXXFLAGS = -Wall -Wextra -Wshadow -std=gnu++11
 # linker flags
 LDFLAGS =
 
-# overridable name of Python executable
-PYTHON ?= python
-
 # build mode (0 - non-verbose, 1 - verbose)
 VERBOSE ?= 0
 
@@ -279,15 +276,10 @@ clean:
 
 .PHONY: board
 board:
-ifeq "3.0.0" "$(word 1, $(sort 3.0.0 $(word 2,$(shell $(PYTHON) --version 2>&1))))"
-	@echo 'This script currently requires Python 2, try:'
-	@echo 'make board PYTHON=python2 CONFIG_FILE=<config_file> [OUTPUT_PATH=<output_path>]'
-else
 ifdef OUTPUT_PATH
 	$(eval OPTIONAL_BOARD_ARGUMENTS := -o $(OUTPUT_PATH))
 endif
-	$(PYTHON) $(DISTORTOS_PATH)scripts/generateBoard.py -c $(CONFIG_FILE) $(OPTIONAL_BOARD_ARGUMENTS)
-endif
+	./$(DISTORTOS_PATH)scripts/generateBoard.py -c $(CONFIG_FILE) $(OPTIONAL_BOARD_ARGUMENTS)
 
 .PHONY: configure
 configure:

--- a/scripts/generateBoard.py
+++ b/scripts/generateBoard.py
@@ -123,7 +123,7 @@ def collectLedsTemplateParams(template_vars, data):
 				if matchObj:
 					ledsPinsGroups.append(matchObj.group())
 
-	template_vars["ledsIds"] = zip(ledsIds, ledsAlternativeIds, ledsPinsGroups)
+	template_vars["ledsIds"] = list(zip(ledsIds, ledsAlternativeIds, ledsPinsGroups))
 	template_vars["ledsPins"] = ledsPins
 
 def collectButtonsTemplateParams(variablesForTemplates, data):
@@ -146,7 +146,7 @@ def collectButtonsTemplateParams(variablesForTemplates, data):
 				if matchObj:
 					buttonsPinsGroup.append(matchObj.group())
 
-	variablesForTemplates["buttonsIds"] = zip(buttonsIds, buttonsPinsGroup)
+	variablesForTemplates["buttonsIds"] = list(zip(buttonsIds, buttonsPinsGroup))
 	variablesForTemplates["buttonsPins"] = buttonsPins
 
 def collectPinGroupsTemplateParams(data):

--- a/scripts/generateBoard.py
+++ b/scripts/generateBoard.py
@@ -153,7 +153,7 @@ def collectPinGroupsTemplateParams(data):
 	pinsType = set()
 	for x in data:
 		pinWithoutNumber = str(x["pin"])
-		pinWithoutNumber = pinWithoutNumber.translate(None, digits)
+		pinWithoutNumber = pinWithoutNumber.strip(digits)
 		pinsType.add(pinWithoutNumber[1:])
 
 	return sorted(pinsType)

--- a/scripts/generateBoard.py
+++ b/scripts/generateBoard.py
@@ -78,7 +78,7 @@ def collectMetaDataFromJinja2File(templateFile):
 			outputTemplates[templateFile]['version'] = str(matchObj.group())
 
 def getTemplateFileFromTypeAndVersion(id, version):
-	for fileName, parameters in outputTemplates.iteritems():
+	for fileName, parameters in outputTemplates.items():
 		if parameters['id'] == id:
 			if (version):
 				if (parameters['version'] == version):
@@ -159,7 +159,7 @@ def collectPinGroupsTemplateParams(data):
 	return sorted(pinsType)
 
 def removeFromOutputTemplatesIfNotConfiguredParam(input_data):
-	for template_path, parameters in outputTemplates.copy().iteritems():
+	for template_path, parameters in outputTemplates.copy().items():
 		if 'type' in parameters:
 			if not parameters['type'] in input_data:
 				del outputTemplates[template_path]
@@ -212,7 +212,7 @@ def main():
 
 	removeFromOutputTemplatesIfNotConfiguredParam(data)
 
-	for pathToTemplate, parameters in outputTemplates.iteritems():
+	for pathToTemplate, parameters in outputTemplates.items():
 		if parameters['id'] == 'outputTemplate':
 			filename = replaceBoardStringInFileName(getOutputFileName(pathToTemplate), templateVars["board"])
 			if(isFileTypeHpp(filename)):

--- a/scripts/generateBoard.py
+++ b/scripts/generateBoard.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 #
 # file: generateBoard.py
 #


### PR DESCRIPTION
Hi @CezaryGapinski ! Could you check this branch? It works here for both versions of Python, but I have the luxury of having the most recent versions possible (3.6.0 and 2.7.13), so its possible that I accidentally broke something for an older version (;

Thanks in advance!