### PR TITLE
Fix whitespaces in dts files

### DIFF
--- a/source/board/STM32/STM32F0/NUCLEO-F091RC/NUCLEO-F091RC.dts
+++ b/source/board/STM32/STM32F0/NUCLEO-F091RC/NUCLEO-F091RC.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F091RC.dtsi"
- 
- / {
- 	compatible = "ST,NUCLEO-F091RC", "ST,STM32F091RC";
- 	model = "STMicroelectronics NUCLEO-F091RC";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F091RC.dtsi"
+
+/ {
+	compatible = "ST,NUCLEO-F091RC", "ST,STM32F091RC";
+	model = "STMicroelectronics NUCLEO-F091RC";
+};

--- a/source/board/STM32/STM32F1/NUCLEO-F103RB/NUCLEO-F103RB.dts
+++ b/source/board/STM32/STM32F1/NUCLEO-F103RB/NUCLEO-F103RB.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F103RB.dtsi"
- 
- / {
- 	compatible = "ST,NUCLEO-F103RB", "ST,STM32F103RB";
- 	model = "STMicroelectronics NUCLEO-F103RB";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F103RB.dtsi"
+
+/ {
+	compatible = "ST,NUCLEO-F103RB", "ST,STM32F103RB";
+	model = "STMicroelectronics NUCLEO-F103RB";
+};

--- a/source/board/STM32/STM32F4/32F429IDISCOVERY/32F429IDISCOVERY.dts
+++ b/source/board/STM32/STM32F4/32F429IDISCOVERY/32F429IDISCOVERY.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F429ZI.dtsi"
- 
- / {
- 	compatible = "ST,32F429IDISCOVERY", "ST,STM32F429ZI";
- 	model = "STMicroelectronics 32F429IDISCOVERY";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F429ZI.dtsi"
+
+/ {
+	compatible = "ST,32F429IDISCOVERY", "ST,STM32F429ZI";
+	model = "STMicroelectronics 32F429IDISCOVERY";
+};

--- a/source/board/STM32/STM32F4/NUCLEO-F401RE/NUCLEO-F401RE.dts
+++ b/source/board/STM32/STM32F4/NUCLEO-F401RE/NUCLEO-F401RE.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F401RE.dtsi"
- 
- / {
- 	compatible = "ST,NUCLEO-F401RE", "ST,STM32F401RE";
- 	model = "STMicroelectronics NUCLEO-F401RE";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F401RE.dtsi"
+
+/ {
+	compatible = "ST,NUCLEO-F401RE", "ST,STM32F401RE";
+	model = "STMicroelectronics NUCLEO-F401RE";
+};

--- a/source/board/STM32/STM32F4/NUCLEO-F429ZI/NUCLEO-F429ZI.dts
+++ b/source/board/STM32/STM32F4/NUCLEO-F429ZI/NUCLEO-F429ZI.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F429ZI.dtsi"
- 
- / {
- 	compatible = "ST,NUCLEO-F429ZI", "ST,STM32F429ZI";
- 	model = "STMicroelectronics NUCLEO-F429ZI";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F429ZI.dtsi"
+
+/ {
+	compatible = "ST,NUCLEO-F429ZI", "ST,STM32F429ZI";
+	model = "STMicroelectronics NUCLEO-F429ZI";
+};

--- a/source/board/STM32/STM32F4/STM32F4DISCOVERY/STM32F4DISCOVERY.dts
+++ b/source/board/STM32/STM32F4/STM32F4DISCOVERY/STM32F4DISCOVERY.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F407VG.dtsi"
- 
- / {
- 	compatible = "ST,STM32F4DISCOVERY", "ST,STM32F407VG";
- 	model = "STMicroelectronics STM32F4DISCOVERY";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F407VG.dtsi"
+
+/ {
+	compatible = "ST,STM32F4DISCOVERY", "ST,STM32F407VG";
+	model = "STMicroelectronics STM32F4DISCOVERY";
+};

--- a/source/board/STM32/STM32F7/32F746GDISCOVERY/32F746GDISCOVERY.dts
+++ b/source/board/STM32/STM32F7/32F746GDISCOVERY/32F746GDISCOVERY.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32F746NG.dtsi"
- 
- / {
- 	compatible = "ST,32F746GDISCOVERY", "ST,STM32F746NG";
- 	model = "STMicroelectronics 32F746GDISCOVERY";
- };
- 
+
+/dts-v1/;
+
+#include "STM32F746NG.dtsi"
+
+/ {
+	compatible = "ST,32F746GDISCOVERY", "ST,STM32F746NG";
+	model = "STMicroelectronics 32F746GDISCOVERY";
+};

--- a/source/board/STM32/STM32L0/NUCLEO-L073RZ/NUCLEO-L073RZ.dts
+++ b/source/board/STM32/STM32L0/NUCLEO-L073RZ/NUCLEO-L073RZ.dts
@@ -8,13 +8,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
- /dts-v1/;
- 
- #include "STM32L073RZ.dtsi"
- 
- / {
- 	compatible = "ST,NUCLEO-L073RZ", "ST,STM32L073RZ";
- 	model = "STMicroelectronics NUCLEO-L073RZ";
- };
- 
+
+/dts-v1/;
+
+#include "STM32L073RZ.dtsi"
+
+/ {
+	compatible = "ST,NUCLEO-L073RZ", "ST,STM32L073RZ";
+	model = "STMicroelectronics NUCLEO-L073RZ";
+};


### PR DESCRIPTION
There was  unnecessary spaces. Probably due to auto-indentation.