### PR TITLE
some addtions

### DIFF
--- a/include/distortos/DynamicSoftwareTimer.hpp
+++ b/include/distortos/DynamicSoftwareTimer.hpp
@@ -1,0 +1,67 @@
+/**
+ * \file
+ * \brief DynamicSoftwareTimer class header
+ *
+ * \author Copyright (C) 2014-2015 Kamil Szczygiel http://www.distortec.com http://www.freddiechopin.info
+ *
+ * \par License
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+ * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef INCLUDE_DISTORTOS_STATICSOFTWARETIMER_HPP_
+#define INCLUDE_DISTORTOS_STATICSOFTWARETIMER_HPP_
+
+#include "distortos/SoftwareTimerCommon.hpp"
+
+#include <functional>
+
+namespace distortos
+{
+
+/// \addtogroup softwareTimers
+/// \{
+
+/**
+ * \brief DynamicSoftwareTimer class is a Timer allowing a (void) function
+ * to run at a later time or at specified intervals.
+ * In contrast to StaticSoftwareTimer, DynamicSoftwareTimer is not a class template.
+ */
+class DynamicSoftwareTimer : public SoftwareTimerCommon
+{
+public:
+	/**
+	 * \brief DynamicSoftwareTimer's constructor
+	 *
+	 * \param [in] function is a function that will be executed from interrupt context at a later time
+	 * \param [in] args are arguments for function
+	 * \tparam Function is the function that will be executed
+	 * \tparam Args are the arguments for function
+	 */
+	template<typename Function, typename... Args>
+	DynamicSoftwareTimer(Function&& function, Args&&... args) :
+			SoftwareTimerCommon{},
+			boundFunction_{std::bind(std::forward<Function>(function), std::forward<Args>(args)...)}
+	{
+	}
+private:
+
+	/**
+	 * \brief "Run" function of software timer
+	 *
+	 * Executes bound function object.
+	 */
+	void run() override
+	{
+		boundFunction_();
+	}
+
+	/// bound function object
+	std::function<void(void)>	boundFunction_;
+};
+
+/// \}
+
+}	// namespace distortos
+
+#endif	// INCLUDE_DISTORTOS_STATICSOFTWARETIMER_HPP_

--- a/include/distortos/ThisThread.hpp
+++ b/include/distortos/ThisThread.hpp
@@ -198,6 +198,16 @@ int sleepUntil(const std::chrono::time_point<TickClock, Duration> timePoint)
 
 void yield();
 
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+/**
+ * \brief Exits the current thread.
+ *
+ * \warning This function must not be called from interrupt context!
+ */
+// [[noreturn]] GCC cannot handle [[noreturn]] virtual functions
+void	exit();
+#endif
+
 /// \}
 
 }	// namespace ThisThread

--- a/include/distortos/ThreadCommon.hpp
+++ b/include/distortos/ThreadCommon.hpp
@@ -133,6 +133,13 @@ public:
 
 	size_t getStackSize() const override;
 
+#ifdef CONFIG_THREAD_DETACH_ENABLE
+	/**
+	 * \return User interface for this thread
+	 */
+	virtual Thread & getThreadInterface(void) { return *this; }
+#endif
+
 	/**
 	 * \return current state of thread
 	 */

--- a/include/distortos/ThreadCommon.hpp
+++ b/include/distortos/ThreadCommon.hpp
@@ -20,6 +20,14 @@
 namespace distortos
 {
 
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+namespace ThisThread
+{
+	// [[noreturn]] GCC cannot handle [[noreturn]] virtual functions
+	void exit();
+}
+#endif
+
 /**
  * \brief ThreadCommon class implements common functionality of threads
  *
@@ -243,8 +251,24 @@ protected:
 
 	static void terminationHook(Thread& thread);
 
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+	// common exit function
+	[[noreturn]]
+	void	exit(void(*const pretermhook)(Thread&), void(&termhook)(Thread&));
 private:
-
+	/**
+	 * \brief Terminates this thread.
+	 * This function must not be called by a thread not being represented by
+	 * this object.\n
+	 * Use ThisThread::exit instead.
+	 *
+	 * \warning This function must not be called from interrupt context!
+	 */
+	[[noreturn]]
+	virtual void exit();
+	friend void ThisThread::exit();
+#endif
+private:
 	/// internal ThreadControlBlock object
 	internal::ThreadControlBlock threadControlBlock_;
 

--- a/include/distortos/internal/scheduler/DynamicThreadBase.hpp
+++ b/include/distortos/internal/scheduler/DynamicThreadBase.hpp
@@ -220,6 +220,14 @@ private:
 
 	static void run(Thread& thread);
 
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+	/**
+	 * \brief Terminates this thread.
+	 */
+	// [[noreturn]] GCC cannot handle [[noreturn]] virtual functions
+	virtual void exit() override;
+#endif
+
 #if CONFIG_SIGNALS_ENABLE == 1
 
 	/// internal DynamicSignalsReceiver object

--- a/include/distortos/internal/scheduler/DynamicThreadBase.hpp
+++ b/include/distortos/internal/scheduler/DynamicThreadBase.hpp
@@ -119,6 +119,13 @@ public:
 
 #endif	// CONFIG_THREAD_DETACH_ENABLE != 1
 
+#ifdef CONFIG_THREAD_DETACH_ENABLE
+	/**
+	 * \return User interface for this thread
+	 */
+	virtual Thread & getThreadInterface(void) override;
+#endif
+
 #if CONFIG_THREAD_DETACH_ENABLE == 1
 
 	/**

--- a/include/distortos/internal/scheduler/ThreadControlBlock.hpp
+++ b/include/distortos/internal/scheduler/ThreadControlBlock.hpp
@@ -28,6 +28,7 @@ namespace distortos
 {
 
 class SignalsReceiver;
+class ThreadCommon;
 
 namespace internal
 {
@@ -78,7 +79,7 @@ public:
 	 */
 
 	ThreadControlBlock(Stack&& stack, uint8_t priority, SchedulingPolicy schedulingPolicy,
-			ThreadGroupControlBlock* threadGroupControlBlock, SignalsReceiver* signalsReceiver, Thread& owner);
+			ThreadGroupControlBlock* threadGroupControlBlock, SignalsReceiver* signalsReceiver, ThreadCommon& owner);
 
 	/**
 	 * \brief ThreadControlBlock's destructor
@@ -137,7 +138,7 @@ public:
 	 * \return reference to Thread object that owns this ThreadControlBlock
 	 */
 
-	Thread& getOwner() const
+	ThreadCommon& getOwner() const
 	{
 		return owner_;
 	}
@@ -314,7 +315,7 @@ private:
 	Stack stack_;
 
 	/// reference to Thread object that owns this ThreadControlBlock
-	Thread& owner_;
+	ThreadCommon & owner_;
 
 	/// list of mutexes (mutex control blocks) with enabled priority protocol owned by this thread
 	MutexList ownedProtocolMutexList_;

--- a/include/distortos/internal/scheduler/threadRunner.hpp
+++ b/include/distortos/internal/scheduler/threadRunner.hpp
@@ -12,6 +12,15 @@
 #ifndef INCLUDE_DISTORTOS_INTERNAL_SCHEDULER_THREADRUNNER_HPP_
 #define INCLUDE_DISTORTOS_INTERNAL_SCHEDULER_THREADRUNNER_HPP_
 
+#include <distortos/distortosConfiguration.h>
+
+// GCC cannot handle [[noreturn]] virtual functions
+#if defined(CONFIG_THREAD_EXIT_ENABLE) && defined(__GNUC__) && !defined(__clang__)
+#define	attrib_noreturn
+#else
+#define	attrib_noreturn __attribute__ ((noreturn))
+#endif // defined(CONFIG_THREAD_EXIT_ENABLE) && defined(__GNUC__) && !defined(__clang__)
+
 namespace distortos
 {
 
@@ -39,7 +48,7 @@ namespace internal
  */
 
 void threadRunner(Thread& thread, void (& run)(Thread&), void (* preTerminationHook)(Thread&),
-		void (& terminationHook)(Thread&)) __attribute__ ((noreturn));
+		void (& terminationHook)(Thread&)) attrib_noreturn;
 
 }	// namespace internal
 

--- a/source/memory/DeferredThreadDeleter.cpp
+++ b/source/memory/DeferredThreadDeleter.cpp
@@ -17,7 +17,7 @@
 
 #include "distortos/internal/scheduler/ThreadControlBlock.hpp"
 
-#include "distortos/Thread.hpp"
+#include "distortos/ThreadCommon.hpp"
 
 namespace distortos
 {

--- a/source/scheduler/Kconfig
+++ b/source/scheduler/Kconfig
@@ -41,6 +41,15 @@ config SIGNALS_ENABLE
 		When this options is not selected, these namespaces, functions and
 		classes are not available at all.
 
+config THREAD_EXIT_ENABLE
+	bool "Enable ThisThread::exit()"
+	default n
+	help
+		Enables exit() function in ThisThread.
+
+		When this options is not selected, a thread has to
+		simply return from its function to exit.
+
 config THREAD_DETACH_ENABLE
 	bool "Enable support for thread detachment"
 	default n

--- a/source/scheduler/ThreadControlBlock.cpp
+++ b/source/scheduler/ThreadControlBlock.cpp
@@ -33,11 +33,10 @@ namespace internal
 | public functions
 +---------------------------------------------------------------------------------------------------------------------*/
 
-#if CONFIG_SIGNALS_ENABLE == 1
 
 ThreadControlBlock::ThreadControlBlock(internal::Stack&& stack, const uint8_t priority,
 		const SchedulingPolicy schedulingPolicy, ThreadGroupControlBlock* const threadGroupControlBlock,
-		SignalsReceiver* const signalsReceiver, Thread& owner) :
+		SignalsReceiver* const signalsReceiver, ThreadCommon& owner) :
 		ThreadListNode{priority},
 		stack_{std::move(stack)},
 		owner_{owner},
@@ -46,38 +45,19 @@ ThreadControlBlock::ThreadControlBlock(internal::Stack&& stack, const uint8_t pr
 		list_{},
 		threadGroupControlBlock_{threadGroupControlBlock},
 		unblockFunctor_{},
+#if CONFIG_SIGNALS_ENABLE == 1
 		signalsReceiverControlBlock_
 		{
 				signalsReceiver != nullptr ? &signalsReceiver->signalsReceiverControlBlock_ : nullptr
 		},
-		roundRobinQuantum_{},
-		schedulingPolicy_{schedulingPolicy},
-		state_{ThreadState::created}
-{
-	_REENT_INIT_PTR(&reent_);
-}
-
-#else	// CONFIG_SIGNALS_ENABLE != 1
-
-ThreadControlBlock::ThreadControlBlock(internal::Stack&& stack, const uint8_t priority,
-		const SchedulingPolicy schedulingPolicy, ThreadGroupControlBlock* const threadGroupControlBlock,
-		SignalsReceiver*, Thread& owner) :
-		ThreadListNode{priority},
-		stack_{std::move(stack)},
-		owner_{owner},
-		ownedProtocolMutexList_{},
-		priorityInheritanceMutexControlBlock_{},
-		list_{},
-		threadGroupControlBlock_{threadGroupControlBlock},
-		unblockFunctor_{},
-		roundRobinQuantum_{},
-		schedulingPolicy_{schedulingPolicy},
-		state_{ThreadState::created}
-{
-	_REENT_INIT_PTR(&reent_);
-}
-
 #endif	// CONFIG_SIGNALS_ENABLE != 1
+		roundRobinQuantum_{},
+		schedulingPolicy_{schedulingPolicy},
+		state_{ThreadState::created}
+{
+	_REENT_INIT_PTR(&reent_);
+}
+
 
 ThreadControlBlock::~ThreadControlBlock()
 {

--- a/source/threads/DynamicThreadBase.cpp
+++ b/source/threads/DynamicThreadBase.cpp
@@ -51,6 +51,13 @@ int DynamicThreadBase::detach()
 
 #endif	// CONFIG_THREAD_DETACH_ENABLE == 1
 
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+void	DynamicThreadBase::exit()
+{
+	ThreadCommon::exit(DynamicThreadBase::preTerminationHook, DynamicThreadBase::terminationHook);
+}
+#endif
+
 /*---------------------------------------------------------------------------------------------------------------------+
 | protected static functions
 +---------------------------------------------------------------------------------------------------------------------*/

--- a/source/threads/DynamicThreadBase.cpp
+++ b/source/threads/DynamicThreadBase.cpp
@@ -58,6 +58,16 @@ void	DynamicThreadBase::exit()
 }
 #endif
 
+#ifdef CONFIG_THREAD_DETACH_ENABLE
+// User interface for this thread
+Thread & DynamicThreadBase::getThreadInterface(void)
+{
+	if ( owner_ )
+		return *owner_;
+	return *this;
+}
+#endif
+
 /*---------------------------------------------------------------------------------------------------------------------+
 | protected static functions
 +---------------------------------------------------------------------------------------------------------------------*/

--- a/source/threads/ThisThread.cpp
+++ b/source/threads/ThisThread.cpp
@@ -16,7 +16,7 @@
 
 #include "distortos/internal/CHECK_FUNCTION_CONTEXT.hpp"
 
-#include "distortos/Thread.hpp"
+#include "distortos/ThreadCommon.hpp"
 
 #include <cerrno>
 
@@ -110,6 +110,13 @@ void yield()
 
 	internal::getScheduler().yield();
 }
+
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+void	exit()
+{
+	internal::getScheduler().getCurrentThreadControlBlock().getOwner().exit();
+}
+#endif
 
 }	// namespace ThisThread
 

--- a/source/threads/ThisThread.cpp
+++ b/source/threads/ThisThread.cpp
@@ -43,7 +43,12 @@ Thread& get()
 {
 	CHECK_FUNCTION_CONTEXT();
 
-	return internal::getScheduler().getCurrentThreadControlBlock().getOwner();
+	auto & thcom = internal::getScheduler().getCurrentThreadControlBlock().getOwner();
+#ifdef CONFIG_THREAD_DETACH_ENABLE
+	return thcom.getThreadInterface();
+#else
+	return thcom;
+#endif
 }
 
 uint8_t getEffectivePriority()

--- a/source/threads/threadRunner.cpp
+++ b/source/threads/threadRunner.cpp
@@ -16,6 +16,9 @@
 #include "distortos/internal/scheduler/Scheduler.hpp"
 
 #include "distortos/InterruptMaskingLock.hpp"
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+#include <distortos/ThisThread.hpp>
+#endif
 
 namespace distortos
 {
@@ -31,7 +34,11 @@ void threadRunner(Thread& thread, void (& run)(Thread&), void (* preTerminationH
 		void (& terminationHook)(Thread&))
 {
 	run(thread);
-
+#ifdef CONFIG_THREAD_EXIT_ENABLE
+	(void)preTerminationHook;
+	(void)terminationHook;
+	ThisThread::exit();
+#else
 	{
 		const InterruptMaskingLock interruptMaskingLock;
 
@@ -44,6 +51,7 @@ void threadRunner(Thread& thread, void (& run)(Thread&), void (* preTerminationH
 	internal::forceContextSwitch();
 
 	while (1);
+#endif
 }
 
 }	// namespace internal


### PR DESCRIPTION
Hi Freddie,
here are some additions. Time was short, so only minor stuff.
I changed the owner of ThreadControlBlock to ThreadCommon. I find it better to pass internal interfaces instead of user interfaces within distortos.

I tried to minimize extra memory consumption for exit(). I think now it should be an additional entry in the vtable of ThreadCommon. Unfortunately, gcc cannot believe in virtual noreturn functions. This makes it a bit ugly here and there.

Regards,
Titus

