### PR TITLE
Fix typo in STM32L0 chip vectors file header description

### DIFF
--- a/source/chip/STM32/STM32L0/STM32L0-chipVectors.cpp
+++ b/source/chip/STM32/STM32L0/STM32L0-chipVectors.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief STM32F0 chip vector table and default weak handlers
+ * \brief STM32L0 chip vector table and default weak handlers
  *
  * \author Copyright (C) 2017 Cezary Gapinski cezary.gapinski@gmail.com
  *


### PR DESCRIPTION
Next typo in STM32L0-chipVectors.cpp ;).