### PR TITLE
Fix typos in STM32L0 RCC header

### DIFF
--- a/source/chip/STM32/STM32L0/include/distortos/chip/STM32L0-RCC.hpp
+++ b/source/chip/STM32/STM32L0/include/distortos/chip/STM32L0-RCC.hpp
@@ -285,4 +285,4 @@ void switchSystemClock(SystemClockSource source);
 
 }	// namespace distortos
 
-#endif	// SOURCE_CHIP_STM32_STM32F0_INCLUDE_DISTORTOS_CHIP_STM32F0_RCC_HPP_
+#endif	// SOURCE_CHIP_STM32_STM32L0_INCLUDE_DISTORTOS_CHIP_STM32L0_RCC_HPP_


### PR DESCRIPTION
More and more typos are fixed... This time in the STM32L0-RC.hpp file.