### PR TITLE
Simplify devices::UartParity to UartParity

### DIFF
--- a/include/distortos/devices/communication/SerialPort.hpp
+++ b/include/distortos/devices/communication/SerialPort.hpp
@@ -365,7 +365,7 @@ public:
 	 * - error codes returned by UartLowLevel::startRead();
 	 */
 
-	int open(uint32_t baudRate, uint8_t characterLength, devices::UartParity parity, bool _2StopBits);
+	int open(uint32_t baudRate, uint8_t characterLength, UartParity parity, bool _2StopBits);
 
 	/**
 	 * \brief Reads data from SerialPort.
@@ -894,7 +894,7 @@ private:
 	uint8_t characterLength_;
 
 	/// current parity
-	devices::UartParity parity_;
+	UartParity parity_;
 
 	/// current configuration of stop bits: 1 (false) or 2 (true)
 	bool _2StopBits_;

--- a/source/devices/communication/SerialPort.cpp
+++ b/source/devices/communication/SerialPort.cpp
@@ -161,7 +161,7 @@ int SerialPort::close()
 	return 0;
 }
 
-int SerialPort::open(const uint32_t baudRate, const uint8_t characterLength, const devices::UartParity parity,
+int SerialPort::open(const uint32_t baudRate, const uint8_t characterLength, const UartParity parity,
 			const bool _2StopBits)
 {
 	readMutex_.lock();


### PR DESCRIPTION
SerialPort and UartParity are in the same namespace, so there is no need to use device:: prefix.