### PR TITLE
Fix headers description in peripheral initializer files

### DIFF
--- a/source/chip/STM32/peripherals/SPIv1/STM32-SPIv1-spiLowLevelInitializer.cpp
+++ b/source/chip/STM32/peripherals/SPIv1/STM32-SPIv1-spiLowLevelInitializer.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief chip::spiLowLevelInitialization() definition for SPIv1 in STM32
+ * \brief Low-level peripheral initializer for SPIv1 in STM32
  *
  * \author Copyright (C) 2016-2018 Kamil Szczygiel http://www.distortec.com http://www.freddiechopin.info
  *

--- a/source/chip/STM32/peripherals/SPIv2/STM32-SPIv2-spiLowLevelInitializer.cpp
+++ b/source/chip/STM32/peripherals/SPIv2/STM32-SPIv2-spiLowLevelInitializer.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief chip::spiLowLevelInitialization() definition for SPIv2 in STM32
+ * \brief Low-level peripheral initializer for SPIv2 in STM32
  *
  * \author Copyright (C) 2016-2018 Kamil Szczygiel http://www.distortec.com http://www.freddiechopin.info
  *

--- a/source/chip/STM32/peripherals/USARTv1/STM32-USARTv1-usartLowLevelInitializer.cpp
+++ b/source/chip/STM32/peripherals/USARTv1/STM32-USARTv1-usartLowLevelInitializer.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief chip::usartLowLevelInitialization() definition for USARTv1 in STM32
+ * \brief Low-level peripheral initializer for USARTv1 in STM32
  *
  * \author Copyright (C) 2016-2018 Kamil Szczygiel http://www.distortec.com http://www.freddiechopin.info
  *

--- a/source/chip/STM32/peripherals/USARTv2/STM32-USARTv2-usartLowLevelInitializer.cpp
+++ b/source/chip/STM32/peripherals/USARTv2/STM32-USARTv2-usartLowLevelInitializer.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief chip::usartLowLevelInitialization() definition for USARTv2 in STM32
+ * \brief Low-level peripheral initializer for USARTv2 in STM32
  *
  * \author Copyright (C) 2016-2018 Kamil Szczygiel http://www.distortec.com http://www.freddiechopin.info
  *


### PR DESCRIPTION
Just simple fixes in peripheral initializers description.